### PR TITLE
added eigen align operator to frame_handler_mono.h and point.h

### DIFF
--- a/svo/include/svo/frame_handler_mono.h
+++ b/svo/include/svo/frame_handler_mono.h
@@ -28,6 +28,8 @@ namespace svo {
 class FrameHandlerMono : public FrameHandlerBase
 {
 public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  
   FrameHandlerMono(vk::AbstractCamera* cam);
   virtual ~FrameHandlerMono();
 

--- a/svo/include/svo/point.h
+++ b/svo/include/svo/point.h
@@ -35,7 +35,8 @@ typedef Matrix<double, 2, 3> Matrix23d;
 class Point : boost::noncopyable
 {
 public:
-
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  
   enum PointType {
     TYPE_DELETED,
     TYPE_CANDIDATE,


### PR DESCRIPTION
It seems to be enough to add the EIGEN_MAKE_ALIGNED_OPERATOR_NEW to the files you suggested in the issue 11 (https://github.com/uzh-rpg/rpg_svo/issues/11). I see you already added it to SparseImgAlign, but it is also needed in FrameHandlerMono.h and Point.h
