### PR TITLE
Fix compatibility with Sophus

### DIFF
--- a/svo/include/svo/frame.h
+++ b/svo/include/svo/frame.h
@@ -17,7 +17,7 @@
 #ifndef SVO_FRAME_H_
 #define SVO_FRAME_H_
 
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 #include <vikit/math_utils.h>
 #include <vikit/abstract_camera.h>
 #include <boost/noncopyable.hpp>

--- a/svo/include/svo/global.h
+++ b/svo/include/svo/global.h
@@ -26,7 +26,7 @@
 
 #include <Eigen/Core>
 #include <opencv2/opencv.hpp>
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 #include <vikit/performance_monitor.h>
 #include <boost/shared_ptr.hpp>
 

--- a/svo/src/bundle_adjustment.cpp
+++ b/svo/src/bundle_adjustment.cpp
@@ -88,9 +88,9 @@ void twoViewBA(
   printf("2-View BA: Error before/after = %f / %f\n", init_error, final_error);
 
   // Update Keyframe Positions
-  frame1->T_f_w_.rotation_matrix() = v_frame1->estimate().rotation().toRotationMatrix();
+  frame1->T_f_w_.rotationMatrix() = v_frame1->estimate().rotation().toRotationMatrix();
   frame1->T_f_w_.translation() = v_frame1->estimate().translation();
-  frame2->T_f_w_.rotation_matrix() = v_frame2->estimate().rotation().toRotationMatrix();
+  frame2->T_f_w_.rotationMatrix() = v_frame2->estimate().rotation().toRotationMatrix();
   frame2->T_f_w_.translation() = v_frame2->estimate().translation();
 
   // Update Mappoint Positions

--- a/svo/src/initialization.cpp
+++ b/svo/src/initialization.cpp
@@ -73,7 +73,7 @@ InitResult KltHomographyInit::addSecondFrame(FramePtr frame_cur)
   double scale = Config::mapScale()/scene_depth_median;
   frame_cur->T_f_w_ = T_cur_from_ref_ * frame_ref_->T_f_w_;
   frame_cur->T_f_w_.translation() =
-      -frame_cur->T_f_w_.rotation_matrix()*(frame_ref_->pos() + scale*(frame_cur->pos() - frame_ref_->pos()));
+      -frame_cur->T_f_w_.rotationMatrix()*(frame_ref_->pos() + scale*(frame_cur->pos() - frame_ref_->pos()));
 
   // For each inlier create 3D point and add feature in both frames
   SE3 T_world_cur = frame_cur->T_f_w_.inverse();
@@ -188,7 +188,7 @@ void computeHomography(
   Homography.computeSE3fromMatches();
   vector<int> outliers;
   vk::computeInliers(f_cur, f_ref,
-                     Homography.T_c2_from_c1.rotation_matrix(), Homography.T_c2_from_c1.translation(),
+                     Homography.T_c2_from_c1.rotationMatrix(), Homography.T_c2_from_c1.translation(),
                      reprojection_threshold, focal_length,
                      xyz_in_cur, inliers, outliers);
   T_cur_from_ref = Homography.T_c2_from_c1;

--- a/svo/src/map.cpp
+++ b/svo/src/map.cpp
@@ -178,7 +178,7 @@ void Map::transform(const Matrix3d& R, const Vector3d& t, const double& s)
   for(auto it=keyframes_.begin(), ite=keyframes_.end(); it!=ite; ++it)
   {
     Vector3d pos = s*R*(*it)->pos() + t;
-    Matrix3d rot = R*(*it)->T_f_w_.rotation_matrix().inverse();
+    Matrix3d rot = R*(*it)->T_f_w_.rotationMatrix().inverse();
     (*it)->T_f_w_ = SE3(rot, pos).inverse();
     for(auto ftr=(*it)->fts_.begin(); ftr!=(*it)->fts_.end(); ++ftr)
     {

--- a/svo/src/matcher.cpp
+++ b/svo/src/matcher.cpp
@@ -112,7 +112,7 @@ bool depthFromTriangulation(
     const Vector3d& f_cur,
     double& depth)
 {
-  Matrix<double,3,2> A; A << T_search_ref.rotation_matrix() * f_ref, f_cur;
+  Matrix<double,3,2> A; A << T_search_ref.rotationMatrix() * f_ref, f_cur;
   const Matrix2d AtA = A.transpose()*A;
   if(AtA.determinant() < 0.000001)
     return false;

--- a/svo/src/point.cpp
+++ b/svo/src/point.cpp
@@ -89,7 +89,7 @@ void Point::initNormal()
   assert(!obs_.empty());
   const Feature* ftr = obs_.back();
   assert(ftr->frame != NULL);
-  normal_ = ftr->frame->T_f_w_.rotation_matrix().transpose()*(-ftr->f);
+  normal_ = ftr->frame->T_f_w_.rotationMatrix().transpose()*(-ftr->f);
   normal_information_ = DiagonalMatrix<double,3,3>(pow(20/(pos_-ftr->frame->pos()).norm(),2), 1.0, 1.0);
   normal_set_ = true;
 }
@@ -134,7 +134,7 @@ void Point::optimize(const size_t n_iter)
     {
       Matrix23d J;
       const Vector3d p_in_f((*it)->frame->T_f_w_ * pos_);
-      Point::jacobian_xyz2uv(p_in_f, (*it)->frame->T_f_w_.rotation_matrix(), J);
+      Point::jacobian_xyz2uv(p_in_f, (*it)->frame->T_f_w_.rotationMatrix(), J);
       const Vector2d e(vk::project2d((*it)->f) - vk::project2d(p_in_f));
       new_chi2 += e.squaredNorm();
       A.noalias() += J.transpose() * J;

--- a/svo/test/test_pipeline.cpp
+++ b/svo/test/test_pipeline.cpp
@@ -26,7 +26,7 @@
 #include <vikit/atan_camera.h>
 #include <vikit/pinhole_camera.h>
 #include <opencv2/opencv.hpp>
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 #include <iostream>
 #include "test_utils.h"
 

--- a/svo_ros/src/benchmark_node.cpp
+++ b/svo_ros/src/benchmark_node.cpp
@@ -17,7 +17,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 #include <ros/ros.h>
 #include <ros/package.h>
 #include <opencv2/opencv.hpp>
@@ -108,7 +108,7 @@ void BenchmarkNode::tracePoseError(const SE3& T_f_gt, const double timestamp)
   trace_trans_error_ << timestamp << " ";
   trace_trans_error_.precision(6);
   trace_trans_error_ << et.x() << " " << et.y() << " " << et.z() << " " << std::endl;
-  Vector3d er(vk::dcm2rpy(T_f_gt.rotation_matrix())); // rotation error in roll-pitch-yaw
+  Vector3d er(vk::dcm2rpy(T_f_gt.rotationMatrix())); // rotation error in roll-pitch-yaw
   trace_rot_error_.precision(15);
   trace_rot_error_.setf(std::ios::fixed, std::ios::floatfield );
   trace_rot_error_ << timestamp << " ";

--- a/svo_ros/src/visualizer.cpp
+++ b/svo_ros/src/visualizer.cpp
@@ -170,7 +170,7 @@ void Visualizer::publishMinimal(
     {
       // publish world in cam frame
       SE3 T_cam_from_world(frame->T_f_w_* T_world_from_vision_);
-      q = Quaterniond(T_cam_from_world.rotation_matrix());
+      q = Quaterniond(T_cam_from_world.rotationMatrix());
       p = T_cam_from_world.translation();
       Cov = frame->Cov_;
     }
@@ -178,7 +178,7 @@ void Visualizer::publishMinimal(
     {
       // publish cam in world frame
       SE3 T_world_from_cam(T_world_from_vision_*frame->T_f_w_.inverse());
-      q = Quaterniond(T_world_from_cam.rotation_matrix()*T_world_from_vision_.rotation_matrix().transpose());
+      q = Quaterniond(T_world_from_cam.rotationMatrix()*T_world_from_vision_.rotationMatrix().transpose());
       p = T_world_from_cam.translation();
       Cov = T_world_from_cam.Adj()*frame->Cov_*T_world_from_cam.inverse().Adj();
     }
@@ -247,7 +247,7 @@ void Visualizer::displayKeyframeWithMps(const FramePtr& frame, int ts)
   // publish keyframe
   SE3 T_world_cam(T_world_from_vision_*frame->T_f_w_.inverse());
   vk::output_helper::publishFrameMarker(
-      pub_frames_, T_world_cam.rotation_matrix(),
+      pub_frames_, T_world_cam.rotationMatrix(),
       T_world_cam.translation(), "kfs", ros::Time::now(), frame->id_*10, 0, 0.015);
 
   // publish point cloud and links
@@ -300,7 +300,7 @@ void Visualizer::exportToDense(const FramePtr& frame)
 
     // publish cam in world frame
     SE3 T_world_from_cam(T_world_from_vision_*frame->T_f_w_.inverse());
-    Quaterniond q(T_world_from_cam.rotation_matrix());
+    Quaterniond q(T_world_from_cam.rotationMatrix());
     Vector3d p(T_world_from_cam.translation());
 
     msg.pose.position.x = p[0];


### PR DESCRIPTION
fix sophus se3.h include and rotation_matrix Eigen bug

Vikit would not compile with latest versions of Sophus.
The header files changed from *.h to *.hpp
rotation_matrix() is deprecated and produces Eigen matrix errors during compilation
