### PR TITLE
Fix seed list memory alignment bug

### DIFF
--- a/svo/include/svo/depth_filter.h
+++ b/svo/include/svo/depth_filter.h
@@ -119,7 +119,7 @@ public:
   void getSeedsCopy(const FramePtr& frame, std::list<Seed>& seeds);
 
   /// Return a reference to the seeds. This is NOT THREAD SAFE!
-  std::list<Seed>& getSeeds() { return seeds_; }
+  std::list<Seed, Eigen::aligned_allocator<Seed>>& getSeeds() { return seeds_; }
 
   /// Bayes update of the seed, x is the measurement, tau2 the measurement uncertainty
   static void updateSeed(
@@ -137,7 +137,7 @@ public:
 protected:
   feature_detection::DetectorPtr feature_detector_;
   callback_t seed_converged_cb_;
-  std::list<Seed> seeds_;
+  std::list<Seed, Eigen::aligned_allocator<Seed>> seeds_;
   boost::mutex seeds_mut_;
   bool seeds_updating_halt_;            //!< Set this value to true when seeds updating should be interrupted.
   boost::thread* thread_;


### PR DESCRIPTION
I was experiencing weird segfaults in DepthFilter::initializeSeeds and the only explanation for it is that the seed list was not aligned the way Eigen expected it, so I made this change and it worked.