### PR TITLE
initialization: remove unused argument in cv::calcOpticalFlowPyrLK

### DIFF
--- a/svo/src/initialization.cpp
+++ b/svo/src/initialization.cpp
@@ -144,7 +144,7 @@ void trackKlt(
                            px_ref, px_cur,
                            status, error,
                            cv::Size2i(klt_win_size, klt_win_size),
-                           4, termcrit, cv::OPTFLOW_USE_INITIAL_FLOW);
+                           4, termcrit, 0);
 
   vector<cv::Point2f>::iterator px_ref_it = px_ref.begin();
   vector<cv::Point2f>::iterator px_cur_it = px_cur.begin();


### PR DESCRIPTION
Fixes #256 